### PR TITLE
Setup package for publish on NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
 import * as path from 'path'
-import { IafUploadModule } from "../interfaces";
+import { IafUploadModule } from './types/interfaces'
 import { MediaConvertDispatcher } from "./mediaconvertDispatcher";
 import { S3Uploader } from "./s3Uploader";
 import { Readable } from "stream";

--- a/lib/mediaconvertDispatcher.ts
+++ b/lib/mediaconvertDispatcher.ts
@@ -1,6 +1,6 @@
 import { CreateJobCommand, MediaConvertClient } from "@aws-sdk/client-mediaconvert";
 import { toPascalCase } from "./utils/stringManipulations";
-import { TranscodeDispatcher } from "../interfaces";
+import { TranscodeDispatcher } from "./types/interfaces";
 import winston from "winston";
 
 import * as emcJob from '../resources/exampleJob.json';

--- a/lib/s3Uploader.ts
+++ b/lib/s3Uploader.ts
@@ -1,5 +1,5 @@
 
-import { Uploader } from "../interfaces";
+import { Uploader } from "./types/interfaces";
 import { Upload } from "@aws-sdk/lib-storage";
 import { S3Client, S3 } from "@aws-sdk/client-s3";
 import { Readable } from "stream";

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -1,18 +1,18 @@
 import { Readable } from "stream";
 import winston from "winston";
 
-interface IafUploadModule {
+export interface IafUploadModule {
     logger: winston.Logger;
     onFileAdd(filePath: string, readStream: Readable): any; 
 }
 
-interface Uploader{
+export interface Uploader{
     destination: string;
     logger: winston.Logger
     upload(fileStream: Readable, fileName: String)
 }
 
-interface TranscodeDispatcher {
+export interface TranscodeDispatcher {
     encodeParams: any,
     inputLocation: string
     outputDestination: string,
@@ -20,7 +20,7 @@ interface TranscodeDispatcher {
     dispatch(fileName: string): Promise<any>
 }
 
-interface FileWatcher {
+export interface FileWatcher {
     dirName: String;
     logger: winston.Logger;
     onAdd(callback: (filePath: string, readStream: Readable) => any)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@eyevinn/iaf-plugin-aws",
   "version": "0.1.0",
   "description": "Ingest application framework plugin for upload and transcode in AWS",
-  "main": "index.js",
+  "main": "./dist/lib/awsModule.js",
+  "types": "./dist/types/lib/awsModule.d.ts",
+  "prepublish": "tsc",
   "scripts": {
     "test": "jest"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,10 @@
       "target": "es6",
       "moduleResolution": "node",
       "sourceMap": true,
-      "outDir": "build",
-      "resolveJsonModule": true
+      "outDir": "dist",
+      "resolveJsonModule": true,
+      "declaration": true,
+      "declarationDir": "dist/types"
     },
     "lib": ["es2015"]
   }


### PR DESCRIPTION
- Changes `tsconfig` to generate type declarations.
- Configures `package.json` to set `AWSUploadModule` as the default export (i.e `import {AWSUploadModule} from 'iaf-plugin-aws' gives the user the entire module)
- Adds `prepublish` to `package.json`, which compiles the typescript before publishing.

All in all, this PR should be what's needed to publish the plugin as an NPM package.
To do after this:
- Remove the AWS modules from iaf repo.
- Expand the iaf.