### PR TITLE
make AWS ARN injectable

### DIFF
--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -11,10 +11,10 @@ export class AwsUploadModule implements IafUploadModule {
     dispatcher: MediaConvertDispatcher;
 
 
-    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, logger: winston.Logger) {
+    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn: string, logger: winston.Logger) {
         this.logger = logger;
         this.uploader = new S3Uploader(ingestBucket, this.logger);
-        this.dispatcher = new MediaConvertDispatcher(mediaConvertEndpoint, awsRegion, ingestBucket, outputBucket, this.logger);
+        this.dispatcher = new MediaConvertDispatcher(mediaConvertEndpoint, awsRegion, ingestBucket, outputBucket, roleArn, this.logger);
     }
 
     /**

--- a/lib/mediaConvertDispatcher.test.ts
+++ b/lib/mediaConvertDispatcher.test.ts
@@ -23,7 +23,7 @@ jest.mock('winston', () => ({
 
 
 const mcMock = mockClient(MediaConvertClient);
-const dispatcher = new MediaConvertDispatcher("testString1", "testRegion1", "inputBucket", "outputBucket", winston.createLogger());
+const dispatcher = new MediaConvertDispatcher("testString1", "testRegion1", "inputBucket", "outputBucket","fakeARN", winston.createLogger());
 
 
 

--- a/lib/mediaConvertDispatcher.ts
+++ b/lib/mediaConvertDispatcher.ts
@@ -3,7 +3,7 @@ import { toPascalCase } from "./utils/stringManipulations";
 import { TranscodeDispatcher } from "./types/interfaces";
 import winston from "winston";
 
-import * as emcJob from '../resources/exampleJob.json';
+import emcJobTemplate from '../resources/exampleJob.json';
 
 export class MediaConvertDispatcher implements TranscodeDispatcher {
     encodeParams: any;
@@ -24,7 +24,7 @@ export class MediaConvertDispatcher implements TranscodeDispatcher {
      * @param logger a logger object
      */
     constructor(mediaConvertEndpoint: string, region: string, inputLocation: string, outputDestination: string, roleArn: string, logger: winston.Logger) {
-        this.encodeParams = emcJob;
+        this.encodeParams = emcJobTemplate;
         this.inputLocation = inputLocation;
         this.outputDestination = outputDestination;
         this.mediaConverterEndpoint = {

--- a/lib/mediaConvertDispatcher.ts
+++ b/lib/mediaConvertDispatcher.ts
@@ -11,15 +11,26 @@ export class MediaConvertDispatcher implements TranscodeDispatcher {
     mediaConverterClient: MediaConvertClient;
     inputLocation: string;
     outputDestination: string;
+    roleArn: string;
     logger: winston.Logger;
 
-    constructor(mediaConvertEndpoint: string, region: string, inputLocation: string, outputDestination: string, logger: winston.Logger) {
+    /**
+     * Initializes a MediaConvertDispatcher
+     * @param mediaConvertEndpoint the unique part of the endpoint to the mediaconvert instance
+     * @param region the AWS region
+     * @param inputLocation the S3 bucket containing the input files
+     * @param outputDestination the S3 bucket where the results should be placed
+     * @param roleArn the role ARN string for AWS
+     * @param logger a logger object
+     */
+    constructor(mediaConvertEndpoint: string, region: string, inputLocation: string, outputDestination: string, roleArn: string, logger: winston.Logger) {
         this.encodeParams = emcJob;
         this.inputLocation = inputLocation;
         this.outputDestination = outputDestination;
         this.mediaConverterEndpoint = {
             endpoint: `https://${mediaConvertEndpoint}.mediaconvert.${region}.amazonaws.com`
         }
+        this.roleArn = roleArn;
         this.logger = logger;
         this.mediaConverterClient = new MediaConvertClient(this.mediaConverterEndpoint);
     }
@@ -31,6 +42,7 @@ export class MediaConvertDispatcher implements TranscodeDispatcher {
      */
     async dispatch(fileName: string) {
         // start by setting the correct input and destination
+        this.encodeParams["Role"] = this.roleArn;
         this.encodeParams["Settings"]["Inputs"].map(input => input["FileInput"] = `s3://${this.inputLocation}/${fileName}`);
         this.encodeParams["Settings"]["OutputGroups"].map(group => {
             const groupName = group["OutputGroupSettings"]["Type"]

--- a/resources/exampleJob.json
+++ b/resources/exampleJob.json
@@ -69,5 +69,5 @@
       "Source": "ZEROBASED"
     }
   },
-  "Role": "arn:aws:iam::590877988961:role/MediaConvert_Default_Role"
+  "Role": "PLACEHOLDER"
 }


### PR DESCRIPTION
- Adds attribute `roleARN` to `MediaConvertDispatcher` to store AWS role string.
- New parameter added to constructors of `MediaConvertDispatcher` and `AWSUploadModule`
- Updated test. 

closes #7 