### PR TITLE
generalize watcher logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fileWatcher.onAdd(awsUploader.onFileAdd);
 # Plugin Documentation
 
 ## `AWSUploadModule`
-Default plugin export. This class is plug-and-play with the Ingest Application Framework, as described in the prevous section.
+Default plugin export. This class is plug-and-play with the Ingest Application Framework, as described in the previous section.
 
 ### Methods
 `constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn:string, playlistName: string, encodeParams: string, logger: winston.Logger)`

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -33,7 +33,7 @@ export class AwsUploadModule implements IafUploadModule {
         try {
             this.uploader.upload(readStream, this.fileName).then(() => {
                 this.dispatcher.dispatch(this.fileName).then(() => {
-                    this.uploader.watcher().then((result) => {
+                    this.uploader.watcher(this.fileName).then((result) => {
                         this.fileUploadedDelegate(result);
                     });
                });

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -14,10 +14,10 @@ export class AwsUploadModule implements IafUploadModule {
     fileUploadedDelegate: Function;
 
 
-    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn: string, playlistName: string, encodeParams: string, logger: winston.Logger) {
+    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn: string, playlistName: string, encodeParams: string, outputFiles: {}, logger: winston.Logger) {
         this.logger = logger;
         this.playlistName = playlistName;
-        this.uploader = new S3Uploader(ingestBucket, outputBucket, this.logger);
+        this.uploader = new S3Uploader(ingestBucket, outputBucket, outputFiles, this.logger);
         this.dispatcher = new MediaConvertDispatcher(mediaConvertEndpoint, awsRegion, ingestBucket, outputBucket, roleArn, this.playlistName, encodeParams, this.logger);
     }
 
@@ -33,7 +33,7 @@ export class AwsUploadModule implements IafUploadModule {
         try {
             this.uploader.upload(readStream, this.fileName).then(() => {
                 this.dispatcher.dispatch(this.fileName).then(() => {
-                    this.uploader.watcher(this.fileName).then((result) => {
+                    this.uploader.watcher().then((result) => {
                         this.fileUploadedDelegate(result);
                     });
                });

--- a/lib/s3Uploader.test.ts
+++ b/lib/s3Uploader.test.ts
@@ -23,7 +23,7 @@ jest.mock('winston', () => ({
 
 import winston from 'winston'
 
-const uploader = new S3Uploader("bucket1", "outputBucket1", winston.createLogger());
+const uploader = new S3Uploader("bucket1", "outputBucket1", {}, winston.createLogger());
 
 const mockUploadInstance = {
     done: jest.fn(),

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -11,6 +11,7 @@ export interface IafUploadModule {
 export interface Uploader {
     destination: string;
     outputDestination: string;
+    outputFiles: {};
     logger: winston.Logger;
     upload(fileStream: Readable, fileName: String)
     watcher(target: string): {};

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -13,8 +13,8 @@ export interface Uploader {
     outputDestination: string;
     outputFiles: {};
     logger: winston.Logger;
-    upload(fileStream: Readable, fileName: String)
-    watcher(target: string): {};
+    upload(fileStream: Readable, fileName: string)
+    watcher(fileName: string): {};
 }
 
 export interface TranscodeDispatcher {


### PR DESCRIPTION
Fixes #15 

The S3 watcher now waits for files set in the `AwsUploadModule` constructor.

The general idea is that the user as before specifies the output bucket, _filename_ (S3 folder after it is converted to HLS/DASH with MediaConvert ) and now also the specific files as an object.

For example:
```
outputFiles = {hls: "manifest.m3u8", dash: "manifest.mpd" };
output_bucket = "output_bucket";
fileName = "filename.mp4";
```
If the watcher can't find the dash manifest file then the object returned by the watcher will be:

`{ "hls": "arn:aws:s3:::output_bucket/filename.mp4/manifest.m3u8", "dash": null }`