### PR TITLE
retry MediaConvert job on error

### DIFF
--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -47,7 +47,7 @@ export class AwsUploadModule implements IafUploadModule {
                                 });
                             } else if (job.Status === "ERROR") {
                                 this.logger.log({
-                                    level: "warn",
+                                    level: "error",
                                     message: `MediaConvert job failed, retrying job!`,
                                 });
                                 this.dispatcher.dispatch(this.fileName).then(() => {

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -42,7 +42,6 @@ export class AwsUploadModule implements IafUploadModule {
                                 });
                                 this.uploader.watcher(this.fileName).then((result) => {
                                     this.fileUploadedDelegate(result);
-                                    return;
                                 });
                             } else if (job.Status === "ERROR") {
                                 this.logger.log({
@@ -56,7 +55,6 @@ export class AwsUploadModule implements IafUploadModule {
                                 });
                             } else {
                                 this.fileUploadedDelegate(result);
-                                return;
                             }
                         });
                     });

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -29,21 +29,46 @@ export class AwsUploadModule implements IafUploadModule {
      * @param readStream Readable stream of the file.
      */
     onFileAdd = (filePath: string, readStream: Readable) => {
+        let RETRIES = 2;
         this.fileName = path.basename(filePath);
         try {
             this.uploader.upload(readStream, this.fileName).then(() => {
-                this.dispatcher.dispatch(this.fileName).then(() => {
+                this.dispatcher.dispatch(this.fileName).then((data) => {
                     this.uploader.watcher(this.fileName).then((result) => {
-                        this.fileUploadedDelegate(result);
+                        this.dispatcher.getJob(data.Job.Id).then((job) => {
+                            if (job.Status === "SUBMITTED" || job.Status === "PROGRESSING") {
+                                this.logger.log({
+                                    level: "warn",
+                                    message: "MediaConvert job did not complete before the watcher timed out, continue to watch for transcoded files!",
+                                });
+                                this.uploader.watcher(this.fileName).then((result) => {
+                                    this.fileUploadedDelegate(result);
+                                    return;
+                                });
+                            } else if (job.Status === "ERROR") {
+                                this.logger.log({
+                                    level: "warn",
+                                    message: `MediaConvert job failed, retrying job!`,
+                                });
+                                this.dispatcher.dispatch(this.fileName).then(() => {
+                                    this.uploader.watcher(this.fileName).then((output) => {
+                                        this.fileUploadedDelegate(output);
+                                    });
+                                });
+                            } else {
+                                this.fileUploadedDelegate(result);
+                                return;
+                            }
+                        });
                     });
-               });
-            })
+                });
+            });
         }
         catch (err) {
             this.logger.log({
-                level: "Error",
+                level: "error",
                 message: `Error when attempting to process file: ${this.fileName}. Full error: ${err}`,
-            })
+            });
         }
     }
 }

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -29,7 +29,6 @@ export class AwsUploadModule implements IafUploadModule {
      * @param readStream Readable stream of the file.
      */
     onFileAdd = (filePath: string, readStream: Readable) => {
-        let RETRIES = 2;
         this.fileName = path.basename(filePath);
         try {
             this.uploader.upload(readStream, this.fileName).then(() => {

--- a/lib/mediaConvertDispatcher.test.ts
+++ b/lib/mediaConvertDispatcher.test.ts
@@ -1,5 +1,5 @@
 import { mockClient } from 'aws-sdk-client-mock';
-import { CreateJobCommand, MediaConvertClient } from '@aws-sdk/client-mediaconvert';
+import { CreateJobCommand, GetJobCommand, MediaConvertClient } from '@aws-sdk/client-mediaconvert';
 import { MediaConvertDispatcher } from './mediaConvertDispatcher';
 import winston from 'winston';
 import * as fs from 'fs';
@@ -49,6 +49,126 @@ const mockParams = {
     "Role": "placeholder"
 }
 
+const getJob = {
+  $metadata: {
+    httpStatusCode: 200,
+    requestId: 'c6ff334a-990f-47ea-80da-1bd825fa04ce',
+    cfId: 'e12345bA==',
+    attempts: 1,
+    totalRetryDelay: 0,
+  },
+  Job: {
+    AccelerationSettings: { Mode: 'DISABLED' },
+    AccelerationStatus: 'NOT_APPLICABLE',
+    Arn: 'arn:aws:mediaconvert:eu-north-1:1234:jobs/123456-61zf86',
+    Id: '123456-61zf86',
+    Messages: { Info: [], Warning: [] },
+    Priority: 0,
+    Queue: 'arn:aws:mediaconvert:eu-north-1:123456789:queues/Default',
+    Role: 'arn:aws:iam::1234:role/MediaConvert_Default_Role',
+    Settings: {
+      Inputs: [
+        {
+          AudioSelectors: {
+            'Audio Selector 1': { DefaultSelection: 'DEFAULT' },
+          },
+          FileInput: 's3://inputBucket/test-file.mp4',
+          TimecodeSource: 'ZEROBASED',
+          VideoSelector: { ColorSpace: 'FOLLOW' },
+        },
+      ],
+      OutputGroups: [
+        {
+          Name: 'HLS',
+          OutputGroupSettings: {
+            HlsGroupSettings: {
+              Destination: 's3://outputBucket/test-file.mp4/manifest',
+              MinSegmentLength: 0,
+              SegmentLength: 6,
+            },
+            Type: 'HLS_GROUP_SETTINGS',
+          },
+          Outputs: [
+            {
+              ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+              NameModifier: '1080p8300',
+              OutputSettings: { HlsSettings: {} },
+              VideoDescription: {
+                CodecSettings: {
+                  Codec: 'H_264',
+                  H264Settings: {
+                    Bitrate: 8300000,
+                    CodecProfile: 'HIGH',
+                    RateControlMode: 'CBR',
+                  },
+                },
+                Height: 1080,
+                Width: 1920,
+              },
+            },
+            {
+              AudioDescriptions: [
+                {
+                  AudioSourceName: 'Audio Selector 1',
+                  CodecSettings: {
+                    AacSettings: {
+                      Bitrate: 192000,
+                      CodecProfile: 'LC',
+                      CodingMode: 'CODING_MODE_2_0',
+                      SampleRate: 44100,
+                    },
+                    Codec: 'AAC',
+                  },
+                  LanguageCode: 'ENG',
+                  LanguageCodeControl: 'USE_CONFIGURED',
+                  StreamName: 'Stereo',
+                },
+              ],
+              ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+              NameModifier: '_stereo',
+              OutputSettings: {
+                HlsSettings: {
+                  AudioGroupId: 'default-audio-group',
+                  AudioTrackType: 'ALTERNATE_AUDIO_AUTO_SELECT',
+                },
+              },
+            },
+            {
+              AudioDescriptions: [
+                {
+                  AudioSourceName: 'Audio Selector 1',
+                  CodecSettings: {
+                    Codec: 'EAC3',
+                    Eac3Settings: {
+                      Bitrate: 384000,
+                      CodingMode: 'CODING_MODE_3_2',
+                    },
+                  },
+                  LanguageCode: 'ENG',
+                  LanguageCodeControl: 'USE_CONFIGURED',
+                  StreamName: 'Surround',
+                },
+              ],
+              ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+              NameModifier: '_51_surround',
+              OutputSettings: {
+                HlsSettings: {
+                  AudioGroupId: 'default-audio-group',
+                  AudioTrackType: 'ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT',
+                },
+              },
+            },
+          ],
+        },
+      ],
+      TimecodeConfig: { Source: 'ZEROBASED' },
+    },
+    Status: 'SUBMITTED',
+    StatusUpdateInterval: 'SECONDS_60',
+    UserMetadata: {},
+  },
+};
+
 jest.mock('winston', () => ({
     format: {
         colorize: jest.fn(),
@@ -72,7 +192,7 @@ const dispatcher = new MediaConvertDispatcher("testString1", "testRegion1", "inp
 beforeEach(() => {
     const logger = winston.createLogger();
     mcMock.reset();
-})
+});
 
 test("Should return transcoding job data on successful dispatch", async () => {
     const mockResp = {
@@ -118,4 +238,121 @@ test("Should throw an error when failing to dispatch the job", async () => {
     await expect(dispatcher.dispatch("filename"))
         .rejects
         .toThrow(mockErr);
-})
+});
+
+test("Should return job info", async () => {
+    const mockResp = {
+        AccelerationSettings: { Mode: 'DISABLED' },
+        AccelerationStatus: 'NOT_APPLICABLE',
+        Arn: 'arn:aws:mediaconvert:eu-north-1:1234:jobs/123456-61zf86',
+        Id: '123456-61zf86',
+        Messages: { Info: [], Warning: [] },
+        Priority: 0,
+        Queue: 'arn:aws:mediaconvert:eu-north-1:123456789:queues/Default',
+        Role: 'arn:aws:iam::1234:role/MediaConvert_Default_Role',
+        Settings: {
+        Inputs: [
+          {
+            AudioSelectors: {
+              'Audio Selector 1': { DefaultSelection: 'DEFAULT' },
+            },
+            FileInput: 's3://inputBucket/test-file.mp4',
+            TimecodeSource: 'ZEROBASED',
+            VideoSelector: { ColorSpace: 'FOLLOW' },
+          },
+        ],
+        OutputGroups: [
+          {
+            Name: 'HLS',
+            OutputGroupSettings: {
+              HlsGroupSettings: {
+                Destination: 's3://outputBucket/test-file.mp4/manifest',
+                MinSegmentLength: 0,
+                SegmentLength: 6,
+              },
+              Type: 'HLS_GROUP_SETTINGS',
+            },
+            Outputs: [
+              {
+                ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+                NameModifier: '1080p8300',
+                OutputSettings: { HlsSettings: {} },
+                VideoDescription: {
+                  CodecSettings: {
+                    Codec: 'H_264',
+                    H264Settings: {
+                      Bitrate: 8300000,
+                      CodecProfile: 'HIGH',
+                      RateControlMode: 'CBR',
+                    },
+                  },
+                  Height: 1080,
+                  Width: 1920,
+                },
+              },
+              {
+                AudioDescriptions: [
+                  {
+                    AudioSourceName: 'Audio Selector 1',
+                    CodecSettings: {
+                      AacSettings: {
+                        Bitrate: 192000,
+                        CodecProfile: 'LC',
+                        CodingMode: 'CODING_MODE_2_0',
+                        SampleRate: 44100,
+                      },
+                      Codec: 'AAC',
+                    },
+                    LanguageCode: 'ENG',
+                    LanguageCodeControl: 'USE_CONFIGURED',
+                    StreamName: 'Stereo',
+                  },
+                ],
+                ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+                NameModifier: '_stereo',
+                OutputSettings: {
+                  HlsSettings: {
+                    AudioGroupId: 'default-audio-group',
+                    AudioTrackType: 'ALTERNATE_AUDIO_AUTO_SELECT',
+                  },
+                },
+              },
+              {
+                AudioDescriptions: [
+                  {
+                    AudioSourceName: 'Audio Selector 1',
+                    CodecSettings: {
+                      Codec: 'EAC3',
+                      Eac3Settings: {
+                        Bitrate: 384000,
+                        CodingMode: 'CODING_MODE_3_2',
+                      },
+                    },
+                    LanguageCode: 'ENG',
+                    LanguageCodeControl: 'USE_CONFIGURED',
+                    StreamName: 'Surround',
+                  },
+                ],
+                ContainerSettings: { Container: 'M3U8', M3u8Settings: {} },
+                NameModifier: '_51_surround',
+                OutputSettings: {
+                  HlsSettings: {
+                    AudioGroupId: 'default-audio-group',
+                    AudioTrackType: 'ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        TimecodeConfig: { Source: 'ZEROBASED' },
+      },
+      Status: 'SUBMITTED',
+      StatusUpdateInterval: 'SECONDS_60',
+      UserMetadata: {},
+    };
+
+    mcMock.on(GetJobCommand).resolves(getJob);
+    const response = await dispatcher.getJob("123456-61zf86");
+    expect(response).toStrictEqual(mockResp);
+});

--- a/lib/mediaConvertDispatcher.ts
+++ b/lib/mediaConvertDispatcher.ts
@@ -1,4 +1,4 @@
-import { CreateJobCommand, MediaConvertClient } from "@aws-sdk/client-mediaconvert";
+import { CreateJobCommand, MediaConvertClient, GetJobCommand } from "@aws-sdk/client-mediaconvert";
 import { toPascalCase } from "./utils/stringManipulations";
 import { TranscodeDispatcher } from "./types/interfaces";
 import * as fs from "fs";
@@ -71,7 +71,28 @@ export class MediaConvertDispatcher implements TranscodeDispatcher {
         catch (err) {
             this.logger.log({
                 level: 'error',
-                message: `Failed to create a transcoding job for ${fileName}! `
+                message: `Failed to create a transcoding job for ${fileName}!`
+            })
+            throw err;
+        }
+    }
+
+    /**
+     * Get a transcode job from a MediaConvert instance
+     * @param jobId the ID of the job to get
+     * @returns the response from AWS.
+     */
+    async getJob(jobId: string) {
+        try {
+            const resp = await this.mediaConverterClient.send(new GetJobCommand({
+                Id: jobId
+            }));
+            return resp.Job;
+        }
+        catch (err) {
+            this.logger.log({
+                level: 'error',
+                message: `Failed to get the transcoding job for ID ${jobId} from MediaConvert!`
             })
             throw err;
         }

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -24,6 +24,7 @@ export interface TranscodeDispatcher {
     logger: winston.Logger;
     playlistName: string;
     dispatch(fileName: string): Promise<any>;
+    getJob(jobId: string): Promise<any>;
 }
 
 export interface FileWatcher {


### PR DESCRIPTION
This PR updates the `onFileAdd` method so that it retries a job if MediaConvert returns status code `ERROR`. If the watcher times out before the transcoding job have finished it will restart the watcher process one more time before timing out and return an error to the user. 