### PR TITLE
add support for providing timeout for S3 watcher in `AWSUploadModule` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,41 +26,48 @@ fileWatcher.onAdd(awsUploader.onFileAdd);
 # Plugin Documentation
 
 ## `AWSUploadModule`
+
 Default plugin export. This class is plug-and-play with the Ingest Application Framework, as described in the previous section.
 
 ### Methods
-`constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn:string, playlistName: string, encodeParams: string, logger: winston.Logger)`
 
-Creates a new `AWSUploadModule` object. You need to provide the unique part your mediaconvert endpoint URL, which AWS region it is running in, as well as the name of your ingest and output buckets. You will also need to provide a role ARN, as well as the base name of the generated playlist. A winston logger is also needed. These parameters are used to initialize the sub-modules.
+`constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn:string, playlistName: string, encodeParams: string, logger: winston.Logger, watcherTimeout: number)`
+
+Creates a new `AWSUploadModule` object. You need to provide the unique part your mediaconvert endpoint URL, which AWS region it is running in, as well as the name of your ingest and output buckets. You will also need to provide a role ARN, as well as the base name of the generated playlist. A winston logger is also needed. If a watcher timeout have been provided the AWS S3 watcher will wait n seconds before it will timeout if no transcoded files have been found in specified outputBucket. These parameters are used to initialize the sub-modules.
 
 `onFileAdd = (filePath: string, readStream: Readable)`.
 
 Method that is executed when a file is added to the directory being watched. `filePath` is the full path to the added file, and `readStream` is a `Readable` stream of the file data. Any file watcher plugins are *required* to provide these. The method uploads the file to the `ingestBucket` specified in the constructor, and dispatches a transcoding job to the MediaConvert endpoint once the upload is completed.
 
 ## `S3Uploader`
+
 Sub-module that handles uploading files to ingest S3 bucket. It's built on top of `@aws-sdk/lib-storage` in order to upload large files, which is essential for video.
 
 ### Methods
-`constructor(destination: string, logger: winston.Logger)`
 
-Instantiates a new `S3Uploader`. `destination` is the name of the ingest bucket (the same as `ingestBucket` in the `AWSUploadModule` constructor). `logger` is injected into the object, in order to avoid multiple logger objects.
+`constructor(destination: string, outputDestination: string, awsRegion: string, outputFiles: {}, logger: winston.Logger, watcherTimeout?: number)`
+
+Instantiates a new `S3Uploader`. `destination` `outputDestination` are the names of the ingest and output buckets (the same as `ingestBucket` and `outputBucket`in the `AWSUploadModule` constructor). `awsRegion`is the AWS region for the input and output bucket, these needs to be in the same location. `outputFiles`are the transcoded files from MediaConvert. `logger` is injected into the object, in order to avoid multiple logger objects. `watcherTimeout` is the same timeout as the one in the `AWSUploadModule` constructor
 
 `async upload(fileStream: Readable, fileName: string)`
 
 Uploads a file to S3. The file data should be provided in the form of a `Readable` stream for performance reasons. `filename` will also be the key used in the S3 bucket.
 
 ## `MediaConvertDispatcher`
+
 Sub-module that dispatches MediaConvert transcoding jobs.
 
 ### Methods
+
 `constructor(mediaConvertEndpoint: string, region: string, inputLocation: string, outputDestination: string, roleArn: string, playlistName: string, logger: winston.Logger)`
 
-Instantiates a new `MediaConverDispatcher`. logging is injected in order to avoid multiple logging objects.
+Instantiates a new `MediaConvertDispatcher`. logging is injected in order to avoid multiple logging objects.
 In most cases, the parameters will be passed down to the parent `AwsUploadModule`.
 
 `async dispatch(fileName: string)`
 
 Dispatches a MediaConverter transcoding job. Jobs are executed with the settings specified in `resources/exampleJob.json`, and are in MediaConvert job format. `fileName` is the S3 key for the input file.
+
 # [Contributing](CONTRIBUTING.md)
 
 In addition to contributing code, you can help to triage issues. This can include reproducing bug reports, or asking for vital information such as version numbers or reproduction instructions.
@@ -69,7 +76,7 @@ TODO: write example code
 
 # License (MIT)
 
-Copyright 2021 Eyevinn Technology
+Copyright 2022 Eyevinn Technology
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/lib/awsModule.ts
+++ b/lib/awsModule.ts
@@ -16,10 +16,10 @@ export class AwsUploadModule implements IafUploadModule {
     progressDelegate: (result: any) => any;
 
 
-    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn: string, playlistName: string, encodeParams: string, outputFiles: {}, logger: winston.Logger) {
+    constructor(mediaConvertEndpoint: string, awsRegion: string, ingestBucket: string, outputBucket: string, roleArn: string, playlistName: string, encodeParams: string, outputFiles: {}, logger: winston.Logger, watcherTimeout?: number) {
         this.logger = logger;
         this.playlistName = playlistName;
-        this.uploader = new S3Uploader(ingestBucket, outputBucket, awsRegion, outputFiles, this.logger);
+        this.uploader = new S3Uploader(ingestBucket, outputBucket, awsRegion, outputFiles, this.logger, watcherTimeout);
         this.dispatcher = new MediaConvertDispatcher(mediaConvertEndpoint, awsRegion, ingestBucket, outputBucket, roleArn, this.playlistName, encodeParams, this.logger);
     }
 

--- a/lib/s3Uploader.test.ts
+++ b/lib/s3Uploader.test.ts
@@ -59,6 +59,18 @@ test("Should resolve on a successful upload", async () => {
     expect(data).toStrictEqual(mockResp)
 })
 
+test("Should resolve on a successful upload with a specific watcher timer", async () => {
+    const uploaderWithTimer = new S3Uploader("bucket1", "outputBucket1", "testRegion1", {}, winston.createLogger(), 300);
+    const mockResp = {
+        '$metadata': {
+            attempts: 1
+        }
+    }
+    mockUploadInstance.done.mockResolvedValueOnce(mockResp);
+    const data = await uploaderWithTimer.upload(mockFile().createReadStream, "filename")
+    expect(data).toStrictEqual(mockResp)
+})
+
 test("Should throw errors when upload fails", async () => {
     const mockErr = "Failed to upload file!"
     mockUploadInstance.done.mockRejectedValueOnce(new Error(mockErr))

--- a/lib/types/interfaces.ts
+++ b/lib/types/interfaces.ts
@@ -6,6 +6,7 @@ export interface Uploader {
     outputDestination: string;
     outputFiles: {};
     region: string;
+    timeout: number;
     logger: winston.Logger;
     upload(fileStream: Readable, fileName: string)
     watcher(fileName: string): {};


### PR DESCRIPTION
Fixes: #25 

This PR adds support for providing the timeout option for a watcher to the `AWSUploadModule` constructor. If the timeout have been set via the env variable `TIMEOUT` the timeout option provided in the constructor will be ignored. 

The default timeout have also been increased to 300 seconds. 